### PR TITLE
Add `Iterable`

### DIFF
--- a/Iterable.js
+++ b/Iterable.js
@@ -1,0 +1,77 @@
+const iterate = require('./utils/iterate');
+const { checkType } = require('./utils/checkType');
+const generateIterable = require('./utils/generateIterable');
+
+const drop = require('./apply/drop');
+const take = require('./apply/take');
+const map = require('./apply/map');
+const filter = require('./apply/filter');
+
+const every = require('./apply/every');
+const some = require('./apply/some');
+
+const reduce = require('./apply/reduce');
+const find = require('./apply/find');
+const len = require('./len');
+
+const forEach = require('./apply/forEach');
+
+class Iterable {
+  constructor(generator, initialType) {
+    this.generator = generator;
+    this.initialType = initialType;
+  }
+
+  static from(iterable) {
+    return new Iterable(iterate(iterable), checkType(iterable));
+  }
+
+  // Returns Iterables
+  drop(limit) {
+    this.generator = drop(this.generator, limit);
+    return this;
+  }
+  take(limit) {
+    this.generator = take(this.generator, limit);
+    return this;
+  }
+  map(callback, thisArg) {
+    this.generator = map(this.generator, callback, thisArg);
+    return this;
+  }
+  filter(callback, thisArg) {
+    this.generator = filter(this.generator, callback, thisArg);
+    return this;
+  }
+
+  // Perform boolean logic
+  every(callback, thisArg) {
+    return every(this.generator, callback, thisArg);
+  }
+  some(callback, thisArg) {
+    return some(this.generator, callback, thisArg);
+  }
+
+  // Return unique value
+  reduce(callback, initialValue = 0, thisArg) {
+    return reduce(this.generator, callback, initialValue, thisArg);
+  }
+  find(callback, thisArg) {
+    return find(this.generator, callback, thisArg);
+  }
+  len() {
+    return len(this.generator);
+  }
+
+  // Browse values
+  forEach(callback, thisArg) {
+    forEach(this.generator, callback, thisArg);
+  }
+
+  // Recreate iterable
+  build(type = this.initialType) {
+    return generateIterable(this.generator, type);
+  }
+}
+
+module.exports = Iterable;

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For all of the functions listed below, you can either do `std.<function>` or imp
 - [find](#find)
 - [every](#every)
 - [some](#some)
+- [Iterable](#iterable)
 
 ### Range
 
@@ -480,4 +481,51 @@ some(x => x <= 2)(
 // true
 some(x => x === '1')('12');
 // true
+```
+
+### Iterator
+
+`Iterator` allows you to chain operations more easily. It supports all these methods:
+
+- `drop`
+- `take`
+- `map`
+- `filter`
+- `every`
+- `some`
+- `reduce`
+- `find`
+- `len`
+- `forEach`
+
+You can also use the method `build()` to reconstruct an iterable (either from the same type as the input, or you can transform it).
+
+#### Supported iterables
+
+- array
+- string
+- Map
+- Set
+- Object
+- iterators
+
+#### Examples
+
+```js
+const iterable = Iterable.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+iterable
+  .drop(1)
+  .filter(x => x % 2 === 0)
+  .map(x => x * 3)
+  .take(2)
+  .build();
+// [6, 12]
+```
+
+`build()` accepts an optional parameter `type`:
+
+```js
+const iterable = Iterable.from([1, 2, 3]);
+iterable.build(type.Set);
+// Set([1, 2, 3])
 ```

--- a/__tests__/Iterable.js
+++ b/__tests__/Iterable.js
@@ -1,0 +1,158 @@
+const Iterable = require('../Iterable');
+const { type } = require('../utils/checkType');
+
+const array = [5, 4, 3, 2, 1, 0];
+const set = new Set(array);
+const string = '543210';
+const object = { a: 5, b: 4, c: 3, d: 2, e: 1, f: 0 };
+const map = new Map(Object.entries(object));
+const inputs = [string, array, set, object, map];
+
+function* iter() {
+  yield* array;
+}
+
+describe('Iterable()', () => {
+  it('should recreate the original iterable', () => {
+    for (const input of inputs) {
+      const iterable = Iterable.from(input);
+      const output = iterable.build();
+      expect(output).toEqual(input);
+    }
+    {
+      const iterable = Iterable.from(iter());
+      const output = [];
+      for (const value of iterable.build()) {
+        output.push(value);
+      }
+      expect(output).toEqual(array);
+    }
+  });
+
+  describe('should create valid other type', () => {
+    it('should create a string', () => {
+      for (const input of [...inputs, iter()]) {
+        const iterable = Iterable.from(input);
+        const output = iterable.build(type.String);
+        expect(output).toEqual(string);
+      }
+    });
+
+    it('should create a array', () => {
+      for (const input of [...inputs, iter()]) {
+        const iterable = Iterable.from(input);
+        const output = iterable.build(type.Array);
+        expect(output.map(x => parseInt(x, 10))).toEqual(array);
+      }
+    });
+
+    it('should create a map', () => {
+      for (const input of [...inputs, iter()]) {
+        const iterable = Iterable.from(input);
+        iterable.map(x => parseInt(x, 10));
+        const output = iterable.build(type.Array);
+        expect(output).toEqual(array);
+      }
+    });
+
+    it('should create a set', () => {
+      for (const input of [...inputs, iter()]) {
+        const iterable = Iterable.from(input);
+        iterable.map(x => parseInt(x, 10));
+        const output = iterable.build(type.Set);
+        expect(output).toEqual(set);
+      }
+    });
+
+    it('should create a object', () => {
+      for (const input of [object, map]) {
+        const iterable = Iterable.from(input);
+        const output = iterable.build(type.Object);
+        expect(output).toEqual(object);
+      }
+      const simpleObject = Object.fromEntries(array.map((x, i) => [i, x]));
+      for (const input of [array, string]) {
+        const iterable = Iterable.from(input);
+        iterable.map(x => parseInt(x, 10));
+        const output = iterable.build(type.Object);
+        expect(output).toEqual(simpleObject);
+      }
+    });
+
+    it('should create a map', () => {
+      for (const input of [object, map]) {
+        const iterable = Iterable.from(input);
+        const output = iterable.build(type.Map);
+        expect(output).toEqual(map);
+      }
+      const simpleMap = new Map(array.map((x, i) => [i, x]));
+      for (const input of [array, string]) {
+        const iterable = Iterable.from(input);
+        iterable.map(x => parseInt(x, 10));
+        const output = iterable.build(type.Map);
+        expect(output).toEqual(simpleMap);
+      }
+    });
+  });
+
+  describe('it includes regular methods', () => {
+    const getIterable = () => Iterable.from(array);
+    it('should work with map, take, drop, filter', () => {
+      const iterable = getIterable();
+      expect(
+        iterable
+          .drop(1)
+          .filter(x => x % 2 === 0)
+          .map(x => x * 3)
+          .take(2)
+          .build(),
+      ).toEqual([12, 6]);
+    });
+    it('should work with every', () => {
+      const iterable = getIterable();
+      expect(iterable.every(x => x >= 0)).toBe(true);
+      // once the iterable has been browsed, it should always return true
+      expect(iterable.every(x => false)).toBe(true);
+    });
+    it('should work with some', () => {
+      const iterable = getIterable();
+      expect(iterable.some(x => x >= 5)).toBe(true);
+      // once the iterable has been browsed, it should always return false
+      expect(iterable.some(x => true)).toBe(false);
+    });
+    it('should work with reduce', () => {
+      const iterable = getIterable();
+      expect(iterable.reduce((acc, cur) => acc + cur, 0)).toBe(15);
+      // once the iterable has been browsed, it doesn't have any value anymore
+      expect(iterable.reduce((acc, cur) => acc + cur, 0)).toBe(0);
+    });
+    it('should work with find', () => {
+      const iterable = getIterable();
+      expect(iterable.find(x => x === 4)).toEqual([4, 1]);
+      expect(iterable.find(x => x === 2)).toEqual([2, 3]);
+      // once one value has been read, find won't read it again
+      expect(iterable.find(x => x === 5)).toEqual(undefined);
+    });
+    it('should work with len', () => {
+      const iterable = getIterable();
+      expect(iterable.find(x => x === 4)).toEqual([4, 1]);
+      expect(iterable.find(x => x === 2)).toEqual([2, 3]);
+      // once one value has been read, find won't read it again
+      expect(iterable.find(x => x === 5)).toEqual(undefined);
+    });
+    it('should work with len', () => {
+      for (const input of [...inputs, iter()]) {
+        const iterable = Iterable.from(input);
+        expect(iterable.len()).toBe(6);
+      }
+    });
+    it('should work with forEach', () => {
+      for (const input of [...inputs, iter()]) {
+        const iterable = Iterable.from(input);
+        const cb = jest.fn();
+        iterable.forEach(cb);
+        expect(cb).toHaveBeenCalledTimes(6);
+      }
+    });
+  });
+});

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -25,7 +25,7 @@ describe('Documentation', () => {
     .toString();
   for (const mod of modules) {
     it(`should document "${mod}"`, () => {
-      const isDocumented = readme.includes(`${mod}(`);
+      const isDocumented = readme.includes(`- [${mod}](#`);
       expect(isDocumented).toBe(true);
     });
   }

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -10,8 +10,11 @@ const std = require('..');
 
 describe('exports', () => {
   for (const mod of modules) {
-    it(`should export ${mod}`, () => {
+    it(`should export '${mod}'`, () => {
       expect(std[mod]).toBe(require(`../${mod}`));
+    });
+    it(`should have tests for "${mod}"`, () => {
+      expect(fs.existsSync(`./${mod}.js`)).toBe(true);
     });
   }
 });
@@ -21,7 +24,7 @@ describe('Documentation', () => {
     .readFileSync(path.join(__dirname, '..', 'README.md'))
     .toString();
   for (const mod of modules) {
-    it(`should document ${mod}`, () => {
+    it(`should document "${mod}"`, () => {
       const isDocumented = readme.includes(`${mod}(`);
       expect(isDocumented).toBe(true);
     });

--- a/apply/find.js
+++ b/apply/find.js
@@ -1,5 +1,10 @@
 function find(generator, callback, thisArg) {
-  for (const step of generator) {
+  while (true) {
+    const next = generator.next();
+    if (next.done) {
+      return;
+    }
+    const step = next.value;
     if (callback.apply(thisArg, step)) {
       return [step[0], step[1]];
     }

--- a/index.js
+++ b/index.js
@@ -14,4 +14,6 @@ module.exports = {
   find: require('./find'),
   some: require('./some'),
   every: require('./every'),
+
+  Iterable: require('./Iterable'),
 };


### PR DESCRIPTION
See: https://github.com/Ayc0/std/issues/1

Add `Iterable` class to better chain operations and avoid re-transforming the iterable at each step